### PR TITLE
add:ER図を追加しました

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ MVP完成　〜5/8
 https://www.figma.com/file/QLL5sBS5FH9SbOdqkbfuxZ/%E6%9C%89%E5%90%89%E5%8F%8D%E7%9C%81%E4%BC%9A-onWeb%E3%80%80%E7%94%BB%E9%9D%A2%E9%81%B7%E7%A7%BB%E5%9B%B3?node-id=0%3A1
 
 ## ER図
-https://drive.google.com/file/d/1lmwerpRiRFSpnk00rJgOCG5jYTik6AQ3/view?usp=sharing
+https://drive.google.com/file/d/1BxZe2iHO0GjB0GOA99aYnZptS8PkokP1/view?usp=sharing

--- a/README.md
+++ b/README.md
@@ -36,3 +36,6 @@ MVP完成　〜5/8
 
 ## 画面遷移図
 https://www.figma.com/file/QLL5sBS5FH9SbOdqkbfuxZ/%E6%9C%89%E5%90%89%E5%8F%8D%E7%9C%81%E4%BC%9A-onWeb%E3%80%80%E7%94%BB%E9%9D%A2%E9%81%B7%E7%A7%BB%E5%9B%B3?node-id=0%3A1
+
+## ER図
+https://drive.google.com/file/d/1lmwerpRiRFSpnk00rJgOCG5jYTik6AQ3/view?usp=sharing


### PR DESCRIPTION
READMEにER図を追加しました。[14ac4b8](https://github.com/ishiguro9913/arikichi-hanseikai/pull/2/commits/14ac4b87f8a9c253592dbe6b60e1064fffb6409f)
ご確認お願いします

ER図 draw.ioリンク
https://drive.google.com/file/d/1lmwerpRiRFSpnk00rJgOCG5jYTik6AQ3/view?usp=sharing

以下ER図説明です

## Usersテーブル
登録ユーザーを保存するテーブル

twitter_id ログインしたユーザーアカウントID
name ユーザーが登録する名前

※ゲストアカウントの場合、twitter_idはnil、nameは「匿名さま」の固定

## Postsテーブル
ユーザーが投稿する反省文のテーブル

user_id ユーザーの外部キー
name 投稿したユーザーの名前
body 反省文の本文
score 採点結果の点数
ablution 反省文に対する禊本文
## Scoresテーブル
反省文の採点結果を登録するテーブル

user_id ユーザーの外部キー
posts_id 投稿された反省文の外部キー
score 採点結果の点数

※twitterログインユーザー・ゲストユーザーに関わらず、採点結果は表示。そのため`post`と採点結果は１対１の関係。

## Ablutionsテーブル
反省文に対する禊を登録するテーブル

user_id ユーザーの外部キー
posts_id 投稿された反省文の外部キー
body 生成された禊の本文

※Twitterログインしたユーザーの投稿のみ禊を生成。
　ゲストユーザーには禊を生成しないため、ユーザーとは１対０以上の関係

## Reactionsテーブル
投稿された反省文に対するリアクションを登録するテーブル

user_id ユーザーの外部キー
posts_id 投稿された反省文の外部キー
good_or_bad 「反省している」「反省していない」のどちらかのリアクション

※ユーザーは１つの投稿に対して、「反省している」「反省していない」のどちらかのみ反応できる。

